### PR TITLE
Fixes for require_keycloak_role

### DIFF
--- a/flask_oidc_ex/__init__.py
+++ b/flask_oidc_ex/__init__.py
@@ -537,8 +537,9 @@ class OpenIDConnect(object):
             @wraps(view_func)
             def decorated(*args, **kwargs):
                 pre, tkn, post = self.get_access_token().split('.')
-                access_token = json.loads(b64decode(tkn + '===')) # fix the potentially missing padding
-                if client in access_token['resource_access'] and role in access_token['resource_access'][client]['roles']:
+                access_token = json.loads(b64decode(tkn + '==='))  # fix the potentially missing padding
+                if client in access_token['resource_access'] and \
+                        role in access_token['resource_access'][client]['roles']:
                     return view_func(*args, **kwargs)
                 else:
                     return abort(403)

--- a/flask_oidc_ex/__init__.py
+++ b/flask_oidc_ex/__init__.py
@@ -537,8 +537,8 @@ class OpenIDConnect(object):
             @wraps(view_func)
             def decorated(*args, **kwargs):
                 pre, tkn, post = self.get_access_token().split('.')
-                access_token = json.loads(b64decode(tkn))
-                if role in access_token['resource_access'][client]['roles']:
+                access_token = json.loads(b64decode(tkn + '===')) # fix the potentially missing padding
+                if client in access_token['resource_access'] and role in access_token['resource_access'][client]['roles']:
                     return view_func(*args, **kwargs)
                 else:
                     return abort(403)

--- a/flask_oidc_ex/__init__.py
+++ b/flask_oidc_ex/__init__.py
@@ -538,7 +538,7 @@ class OpenIDConnect(object):
             def decorated(*args, **kwargs):
                 pre, tkn, post = self.get_access_token().split('.')
                 access_token = json.loads(b64decode(tkn + '==='))  # fix the potentially missing padding
-                if client in access_token['resource_access'] and \
+                if 'resource_access' in access_token and client in access_token['resource_access'] and \
                         role in access_token['resource_access'][client]['roles']:
                     return view_func(*args, **kwargs)
                 else:


### PR DESCRIPTION
First, fix issue with missing padding for the part of the token that contains the json text.
Second, make sure that client is in the loaded dictionary, before attempting to index into it.